### PR TITLE
Add concurrency, sort order flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ For `use-package` user:
 (setq flycheck-gometalinter-enable-linters '("golint"))
 ;; Set different deadline (default: 5s)
 (setq flycheck-gometalinter-deadline "10s")
+;; Set gometalinter concurrency (default: 16)
+(setq flycheck-gometalinter-concurrency "16")
+;; Set gometalinter output sort order (default: none)
+(setq flycheck-gometalinter-sort "lines")
 ```
 
 [flycheck-ref]: http://www.flycheck.org                 "Flycheck"

--- a/flycheck-gometalinter.el
+++ b/flycheck-gometalinter.el
@@ -81,6 +81,14 @@ flycheck-gometalinter-enable-linters."
   duration."
   :safe #'stringp)
 
+(flycheck-def-option-var flycheck-gometalinter-concurrency "16" gometalinter
+  "Number of linters to run concurrently."
+  :safe #'stringp)
+
+(flycheck-def-option-var flycheck-gometalinter-sort "none" gometalinter
+  "Sort output by any of none, path, line, column, severity, message, linter."
+  :safe #'stringp)
+
 (flycheck-define-checker gometalinter
   "A all-in-one Go linter.
 See URL: `https://github.com/alecthomas/gometalinter'"
@@ -89,7 +97,9 @@ See URL: `https://github.com/alecthomas/gometalinter'"
             (option-flag "--disable-all" flycheck-gometalinter-disable-all)
             (option-flag "--fast" flycheck-gometalinter-fast)
             (option-flag "--tests" flycheck-gometalinter-tests)
+            (option "--concurrency=" flycheck-gometalinter-concurrency concat)
             (option "--deadline=" flycheck-gometalinter-deadline concat)
+            (option "--sort=" flycheck-gometalinter-sort concat)
             (option-list "--disable=" flycheck-gometalinter-disable-linters concat)
             (option-list "--enable=" flycheck-gometalinter-enable-linters concat)
             ".")


### PR DESCRIPTION
Adds two flags, concurrency and sort order, that gometalinter supports but flycheck-gometalinter doesn't (yet).

```
-j, --concurrency=16      Number of concurrent linters to run.
    --sort=none ...       Sort output by any of none, path, line, column, severity, message, linter.
```
