### PR TITLE
Fix tiny typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For `use-package` user:
 ;; only run fast linters
 (setq flycheck-gometalinter-fast t)
 ;; use in tests files
-(setq flycheck-gometalinter-test t)
+(setq flycheck-gometalinter-tests t)
 ;; disable linters
 (setq flycheck-gometalinter-disable-linters '("gotype" "gocyclo"))
 ;; Only enable selected linters


### PR DESCRIPTION
Update the reference to the correct option `flycheck-gometalinter-tests`:

```elisp
(flycheck-def-option-var flycheck-gometalinter-tests nil gometalinter
  "Include test files for linters that support this option."
  :safe #'booleanp
  :type 'boolean)
```